### PR TITLE
Porting Initializer Tests from ember.js repo

### DIFF
--- a/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/files/tests/unit/initializers/__name__-test.js
@@ -1,0 +1,31 @@
+import Application from '@ember/application';
+
+import { initialize } from '<%= dasherizedModulePrefix %>/initializers/<%= dasherizedModuleName %>';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import destroyApp from '../../helpers/destroy-app';
+
+module('<%= friendlyTestName %>', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.TestApplication = Application.extend();
+    this.TestApplication.initializer({
+      name: 'initializer under test',
+      initialize
+    });
+
+    this.application = this.TestApplication.create({ autoboot: false });
+  });
+
+  hooks.afterEach(function() {
+    destroyApp(this.application);
+  });
+
+  // Replace this with your real tests.
+  test('it works', async function(assert) {
+    await this.application.boot();
+
+    assert.ok(true);
+  });
+});

--- a/blueprints/initializer-test/index.js
+++ b/blueprints/initializer-test/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/* eslint-env node */
+
+const testInfo = require('ember-cli-test-info');
+const stringUtils = require('ember-cli-string-utils');
+
+module.exports = {
+  description: 'Generates an initializer unit test.',
+  locals: function(options) {
+    return {
+      friendlyTestName: testInfo.name(options.entity.name, 'Unit', 'Initializer'),
+      dasherizedModulePrefix: stringUtils.dasherize(options.project.config().modulePrefix)
+    };
+  }
+};

--- a/node-tests/blueprints/initializer-test-test.js
+++ b/node-tests/blueprints/initializer-test-test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+const modifyPackages = blueprintHelpers.modifyPackages;
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+const fixture = require('../helpers/fixture');
+
+describe('Blueprint: initializer-test', function() {
+  setupTestHooks(this);
+
+  describe('in app', function() {
+    beforeEach(function() {
+      return emberNew();
+    });
+
+    describe('with ember-qunit-nested-module-blueprints-polyfill', function() {
+
+      it('initializer-test foo', function() {
+        return emberGenerateDestroy(['initializer-test', 'foo'], _file => {
+          expect(_file('tests/unit/initializers/foo-test.js'))
+          .to.equal(fixture('initializer-test/rfc232.js'));
+        });
+      });
+    });
+
+  });
+
+});

--- a/node-tests/fixtures/initializer-test/rfc232.js
+++ b/node-tests/fixtures/initializer-test/rfc232.js
@@ -1,0 +1,31 @@
+import Application from '@ember/application';
+
+import { initialize } from 'my-app/initializers/foo';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import destroyApp from '../../helpers/destroy-app';
+
+module('Unit | Initializer | foo', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.TestApplication = Application.extend();
+    this.TestApplication.initializer({
+      name: 'initializer under test',
+      initialize
+    });
+
+    this.application = this.TestApplication.create({ autoboot: false });
+  });
+
+  hooks.afterEach(function() {
+    destroyApp(this.application);
+  });
+
+  // Replace this with your real tests.
+  test('it works', async function(assert) {
+    await this.application.boot();
+
+    assert.ok(true);
+  });
+});


### PR DESCRIPTION
See https://github.com/emberjs/ember.js/issues/15933

- https://github.com/emberjs/ember.js/blob/master/blueprints/initializer-test/index.js
- https://github.com/emberjs/ember.js/blob/master/blueprints/initializer-test/qunit-rfc-232-files/tests/unit/initializers/__name__-test.js
- https://github.com/emberjs/ember.js/blob/master/node-tests/fixtures/initializer-test/rfc232.js
- https://github.com/emberjs/ember.js/blob/master/node-tests/blueprints/initializer-test-test.js