### PR TITLE
Porting Route Tests from ember.js repo

### DIFF
--- a/blueprints/route-test/files/tests/unit/__path__/__test__.js
+++ b/blueprints/route-test/files/tests/unit/__path__/__test__.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('<%= friendlyTestDescription %>', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:<%= moduleName %>');
+    assert.ok(route);
+  });
+});

--- a/blueprints/route-test/index.js
+++ b/blueprints/route-test/index.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/* eslint-env node */
+
+const testInfo = require('ember-cli-test-info');
+const path = require('path');
+const stringUtil = require('ember-cli-string-utils');
+
+module.exports = {
+  description: 'Generates a route unit test.',
+
+  availableOptions: [
+    {
+      name: 'reset-namespace',
+      type: Boolean
+    }
+  ],
+
+  fileMapTokens: function() {
+    return {
+      __test__: function (options) {
+        let moduleName = options.locals.moduleName;
+
+        if (options.pod) {
+          moduleName = 'route';
+        }
+
+        return `${moduleName}-test`;
+      },
+      __path__: function(options) {
+        if (options.pod) {
+          return path.join(options.podPath, options.locals.moduleName);
+        }
+        return 'routes';
+      }
+    };
+  },
+
+  locals: function(options) {
+    let moduleName = options.entity.name;
+
+    if (options.resetNamespace) {
+      moduleName = moduleName.split('/').pop();
+    }
+
+    return {
+      friendlyTestDescription: testInfo.description(options.entity.name, 'Unit', 'Route'),
+      moduleName: stringUtil.dasherize(moduleName)
+    };
+  },
+};

--- a/node-tests/blueprints/route-test-test.js
+++ b/node-tests/blueprints/route-test-test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+const setupTestHooks = blueprintHelpers.setupTestHooks;
+const emberNew = blueprintHelpers.emberNew;
+const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+const modifyPackages = blueprintHelpers.modifyPackages;
+
+const chai = require('ember-cli-blueprint-test-helpers/chai');
+const expect = chai.expect;
+
+const fixture = require('../helpers/fixture');
+
+describe('Blueprint: route-test', function() {
+  setupTestHooks(this);
+
+  describe('in app', function() {
+    beforeEach(function() {
+      return emberNew();
+    });
+
+    describe('with ember-qunit-nested-module-blueprints-polyfill', function() {
+
+      it('route-test foo', function() {
+        return emberGenerateDestroy(['route-test', 'foo'], (_file) => {
+          expect(_file('tests/unit/routes/foo-test.js'))
+          .to.equal(fixture('route-test/rfc232.js'));
+        });
+      });
+    });
+
+  });
+
+});

--- a/node-tests/fixtures/route-test/rfc232.js
+++ b/node-tests/fixtures/route-test/rfc232.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | foo', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:foo');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
See https://github.com/emberjs/ember.js/issues/15933

- https://github.com/emberjs/ember.js/blob/master/blueprints/route-test/index.js
- https://github.com/emberjs/ember.js/blob/master/blueprints/route-test/qunit-rfc-232-files/tests/unit/__path__/__test__.js
- https://github.com/emberjs/ember.js/blob/master/node-tests/fixtures/route-test/rfc232.js
- https://github.com/emberjs/ember.js/blob/master/node-tests/blueprints/route-test-test.js