### PR TITLE
Fix spacing error in mixin test

### DIFF
--- a/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/files/tests/unit/mixins/__name__-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 
 module('<%= friendlyTestName %>', function() {
   // Replace this with your real tests.
-  test('it works', function (assert) {
+  test('it works', function(assert) {
     let <%= classifiedModuleName %>Object = EmberObject.extend(<%= classifiedModuleName %>Mixin);
     let subject = <%= classifiedModuleName %>Object.create();
     assert.ok(subject);

--- a/node-tests/fixtures/mixin-test/rfc232.js
+++ b/node-tests/fixtures/mixin-test/rfc232.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Mixin | foo', function() {
   // Replace this with your real tests.
-  test('it works', function (assert) {
+  test('it works', function(assert) {
     let FooObject = EmberObject.extend(FooMixin);
     let subject = FooObject.create();
     assert.ok(subject);


### PR DESCRIPTION
Remove the space before the function paren to match the style of all the other test blueprints